### PR TITLE
Allow desktop icons to be passed attributes in object

### DIFF
--- a/src/os.js
+++ b/src/os.js
@@ -76,7 +76,7 @@ function Task($win){
 	});
 }
 
-function $DesktopIcon(title, icon_name, exe, is_shortcut){
+function $DesktopIcon(title, icon_name, exe, is_shortcut, params){
 	var $container = $("<div class='desktop-icon' draggable='true'/>").appendTo($desktop);
 	var $icon_wrapper = $("<div class='icon-wrapper'/>").appendTo($container).width(DESKTOP_ICON_SIZE).height(DESKTOP_ICON_SIZE);
 	var $icon = $Icon([icon_name, "task"], DESKTOP_ICON_SIZE).width(DESKTOP_ICON_SIZE).height(DESKTOP_ICON_SIZE);
@@ -84,7 +84,7 @@ function $DesktopIcon(title, icon_name, exe, is_shortcut){
 	$container.append($icon_wrapper, $title);
 	$icon_wrapper.append($icon);
 	$container.on("dblclick", function(){
-		new exe
+		new exe(params)
 	});
 	$container.on("pointerdown", function(){
 		$desktop.find(".desktop-icon").removeClass("selected");


### PR DESCRIPTION
I'm adding this on my own fork so I can pass in files to programs. For example having a general Notepad function but allowing instances (e.g. myNote.txt) to be passed in. 

I thought it might be useful for other programs as well. For example with paint you may want to have an icon representing a specific picture which was painted.

Let me know what you think.