### PR TITLE
Minesweeper win and lose faces

### DIFF
--- a/programs/minesweeper/face.js
+++ b/programs/minesweeper/face.js
@@ -15,7 +15,7 @@ minesweeper.face.prototype.get_element = function() {
     this.element = $.createElement("div")
       .style({"width": 26, "height": 26, "margin": "auto", "background-image": minesweeper.sprite, "background-repeat": "no-repeat"})
       .addEventListener("mousedown", function() {
-        if(self.state === "smile") self.set_state("depressed_smile");
+        self.set_state("depressed_smile");
       })
       .addEventListener("mouseup", function() {
         if(self.state === "depressed_smile") {

--- a/programs/minesweeper/menus.js
+++ b/programs/minesweeper/menus.js
@@ -17,6 +17,8 @@ var set_difficulty = function(difficulty){
 			height: extra_height + tile_size * difficulty[1],
 		});
 	}
+	// got this from the $menu_bar close_menu function
+	$menu_bar.find(".menu-button").trigger("release");
 };
 var is_at_difficulty = function(difficulty){
 	return (

--- a/programs/minesweeper/minesweeper.js
+++ b/programs/minesweeper/minesweeper.js
@@ -150,6 +150,7 @@ minesweeper.prototype.lose = function() {
 minesweeper.prototype.win = function() {
   if(!this.game_over) {
     clearInterval(this.timer_interval);
+    this.face.set_state("sunglasses");
     this.game_over = true;
     // alert('You win!');
   }

--- a/programs/minesweeper/minesweeper.js
+++ b/programs/minesweeper/minesweeper.js
@@ -116,21 +116,23 @@ minesweeper.prototype.new_game = function(width, height, number_mines) {
 
   var face = new minesweeper.face(this, this.header_td_face);
 
+  this.face = face;
+
   this.play_table.removeEventListener("mousedown,mouseup").style({"cursor": "default", "border": "1px solid #444"});
   this.play_table
     .addEventListener("mousedown", function(e) {
       if(e.target === face.get_element()) return false;
-      if(e.which === 1) face.set_state("scared");
+      if(e.which === 1 && !self.game_over) face.set_state("scared");
     })
     .addEventListener("mouseup", function(e) {
-      face.set_state("smile");
+      if(!self.game_over) face.set_state("smile");
     });
 
   this.mine_counter = new minesweeper.ssd(this.header_td_mine_count, number_mines)
   var timer = new minesweeper.ssd(this.header_td_timer, 0);
 
   this.timer_interval = setInterval(function() { timer.increment(); }, 1000);
-
+;
 	this.grid = new minesweeper.grid(this, this.grid_area, width, height, face);
 	this.grid.generate(number_mines);
 }
@@ -141,6 +143,7 @@ minesweeper.prototype.lose = function() {
   if(!this.game_over) {
     clearInterval(this.timer_interval);
     this.game_over = true;
+    this.face.set_state("dead");
     // alert('You lose!');
   }
 }
@@ -238,7 +241,7 @@ $.ready(function() {
           }
 
         }
-        else { // Single tile reveals are simple
+        else if(!minesweeper_.game_over) { // Single tile reveals are simple
           minesweeper_.grid.reveal_area(click_coordinates.x, click_coordinates.y);
         }
 


### PR DESCRIPTION
I've made a few changes to minesweeper to make it closer to the real deal in win98: 

- Use the "dead" face when picking a mine, also disable clicks on field when all mines are revealed

- Use the "sunglasses" face when all mines are correctly marked

- Close the menubar when selecting difficulty