### PR TITLE
Added removal of card throw when clicking deal

### DIFF
--- a/programs/js-solitaire/src/index.js
+++ b/programs/js-solitaire/src/index.js
@@ -203,6 +203,9 @@ const placeCardTo = (dest, index, card) => {
 };
 
 function dealCards() {
+    // trigger removeAnimation after win
+    document.querySelector('canvas')?.click();
+
     let card = 0;
     for (let i = 0; i < 7; i++) {
         for (let j = i; j < 7; j++) {


### PR DESCRIPTION
Hello, I noticed that, the game doesn't reset, when clicking "Deal", while the card throw particle effect is being shown. The game however resets, when clicking on the canvas.
I added a one line workaround, that trickers a click event on the canvas after clicking "Deal".

Before

https://github.com/1j01/98/assets/6861911/ee0608c7-b49c-4a05-aede-2d3bd6a6a10b

After

https://github.com/1j01/98/assets/6861911/d33af988-a6df-4d92-8f6f-4a671b6a818f

Cheers